### PR TITLE
add terminal service

### DIFF
--- a/lib/terminus.coffee
+++ b/lib/terminus.coffee
@@ -10,6 +10,17 @@ module.exports =
   consumeStatusBar: (statusBarProvider) ->
     @statusBarTile = new (require './status-bar')(statusBarProvider)
 
+  provideTerminal: ->
+    updateProcessEnv: (variables) ->
+      for name, value of variables
+        process.env[name] = value
+    run: (commands) =>
+      @statusBarTile.runCommandInNewTerminal commands
+    getTerminalViews: () =>
+      @statusBarTile.terminalViews
+    open: () =>
+      @statusBarTile.runNewTerminal()
+
   config:
     toggles:
       type: 'object'

--- a/package.json
+++ b/package.json
@@ -71,5 +71,13 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
+  },
+  "providedServices": {
+    "terminal": {
+      "description": "Terminal API",
+      "versions": {
+        "1.0.0": "provideTerminal"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Pull request details
- [x] This PR implements a new feature or introduces new behavior.

### Description of the change

Provide a service called terminal to allow other packages.

This service is exactly the same as [`platformioIDETerminal`](https://github.com/platformio/platformio-atom-ide-terminal/blob/f61084493ed48db11d2e54d39e01c1b88e693654/package.json#L60-L64) service provided by `platformio-ide-terminal`.

fixes #1

<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->

### Notes

Provide `terminal` service for other packages to interact with the terminals.

<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand.
-->
