### PR TITLE
render in dock

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -1,8 +1,10 @@
 {CompositeDisposable} = require 'atom'
 {$, View} = require 'atom-space-pen-views'
 
+InputDialog = null
 TerminusView = require './view'
 StatusIcon = require './status-icon'
+{getDockSetting} = require './utils'
 
 os = require 'os'
 path = require 'path'
@@ -19,6 +21,7 @@ class StatusBar extends View
       @i class: "icon icon-plus", click: 'newTerminalView', outlet: 'plusBtn'
       @ul class: "list-inline status-container", tabindex: '-1', outlet: 'statusContainer', is: 'space-pen-ul'
       @i class: "icon icon-x", click: 'closeAll', outlet: 'closeBtn'
+      if not getDockSetting() then null else @i class: 'icon icon-keyboard', style: 'margin-left: 10px', outlet: 'inputBtn', click: 'inputDialog'
 
   initialize: (@statusBarProvider) ->
     @subscriptions = new CompositeDisposable()
@@ -78,7 +81,8 @@ class StatusBar extends View
               nextTerminal = @createTerminalView()
           else
             @setActiveTerminalView(nextTerminal)
-            nextTerminal.toggle() if prevTerminal?.panel.isVisible()
+            if prevTerminal?.panel?.isVisible() or atom.workspace.getBottomDock().isVisible()
+              nextTerminal.toggle()
 
     @registerContextMenu()
 
@@ -311,6 +315,12 @@ class StatusBar extends View
       if view?
         view.destroy()
     @activeTerminal = null
+
+  inputDialog: ->
+    if not @activeTerminal then return
+    InputDialog ?= require('./input-dialog')
+    dialog = new InputDialog @activeTerminal
+    dialog.attach()
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/terminus.coffee
+++ b/lib/terminus.coffee
@@ -2,6 +2,10 @@ module.exports =
   statusBar: null
 
   activate: ->
+    atom.config.onDidChange 'terminus.toggles.useDock', (event) =>
+      if @statusBarProvider
+        @deactivate()
+        @consumeStatusBar(@statusBarProvider)
 
   deactivate: ->
     @statusBarTile?.destroy()
@@ -26,6 +30,11 @@ module.exports =
       type: 'object'
       order: 1
       properties:
+        useDock:
+          title: 'Use Bottom Dock'
+          description: 'Should the terminals be rendered in a dock?'
+          type: 'boolean'
+          default: false
         autoClose:
           title: 'Close Terminal on Exit'
           description: 'Should the terminal close if the shell exits?'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,18 @@
+"use babel";
+
+const isString = x => typeof x === "string";
+
+// visibility for items in bottom dock
+export function isVisible(itemOrUri) {
+  const uri = isString(itemOrUri) ? itemOrUri : itemOrUri.getURI();
+
+  const dock = atom.workspace.getBottomDock();
+  if (!dock.isVisible()) return false;
+
+  const activeItem = dock.getActivePaneItem();
+  if (!activeItem) return false;
+
+  return activeItem.getURI && activeItem.getURI() === uri;
+}
+
+export const getDockSetting = () => atom.config.get("terminus.toggles.useDock");

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -123,7 +123,7 @@ class TerminusView extends View
 
   updateToolbarVisibility: =>
     if !@shouldUseDock
-      @showToolbar = atom.config.get('platformio-ide-terminal.toggles.showToolbar')
+      @showToolbar = atom.config.get('terminus.toggles.showToolbar')
       if @showToolbar
         @toolbar.css 'display', 'block'
       else

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -289,7 +289,7 @@ class TerminusView extends View
         @opened = true
         @displayTerminal()
         @xterm.height("100%")
-        @emit "terminusl:terminal-open"
+        @emit "terminus:terminal-open"
       else @focus()
     
   hide: =>


### PR DESCRIPTION
This pr takes the work done [here](https://github.com/platformio/platformio-atom-ide-terminal/pull/697)
with a few refactors
adds the option to render terminals in the bottom dock