### PR TITLE
Break out of switch cases responding to process events

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -52,9 +52,18 @@ module.exports = function(pwd, shell, args, env, options = {}) {
 
   return process.on('message', function({event, cols, rows, text}={}) {
     switch (event) {
-      case 'resize': ptyProcess.resize(cols, rows);
-      case 'input': ptyProcess.write(text);
-      case 'pty': emit('terminus:pty', ptyProcess.pty);
+      case 'resize': {
+        ptyProcess.resize(cols, rows);
+        break;
+      }
+      case 'input': {
+        ptyProcess.write(text);
+        break;
+      }
+      case 'pty': {
+        emit('terminus:pty', ptyProcess.pty);
+        break;
+      }
     }
   });
 };


### PR DESCRIPTION
On mac, the initial resize event would cause the switch to cascade into the input case and `ptyProcess` would throw an error about the argument to `ptyProcess.write` being undefined.
Then keyboard input wouldn't work at all in any terminal panel.