### PR TITLE
feat: add cursor properties

### DIFF
--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -50,6 +50,13 @@ module.exports = {
           type: 'boolean',
           default: true
         },
+        cursorProperties: {
+          title: 'Cursor Properties',
+          description: 'Select your cursor style shape',
+          type: 'string',
+          default: 'Block',
+          enum: ['Block', 'I-Beam', 'Underline']
+        },
         runInsertedText: {
           title: 'Run Inserted Text',
           description: 'Run text inserted via `terminus:insert-text` as a command? **This will append an end-of-line character to input.**',

--- a/lib/view.js
+++ b/lib/view.js
@@ -391,6 +391,27 @@ class TerminusView extends View {
 
     if (config.toggles.cursorBlink) { this.xterm.addClass('cursor-blink') }
 
+    switch (atom.config.get('terminus.toggles.cursorProperties')) {
+      default:
+        this.xterm.addClass('terminal-cursor')
+        break
+      case 'I-Beam':
+        this.xterm.addClass('terminal-cursor')
+        this.xterm.css('width', '2px;')
+        this.xterm.css('height', 'auto;')
+        break
+      case 'Underline':
+        this.xterm.addClass('terminal-cursor')
+        this.xterm.css('width', 'auto;')
+        this.xterm.css('height', '2px;')
+        break
+    }
+
+    this.subscriptions.add(atom.config.onDidChange('terminus.toggles.cursorProperties', event => {
+      this.xterm.removeClass(event.oldValue)
+      this.xterm.addClass(event.newValue)
+    }))
+
     let editorFont = atom.config.get('editor.fontFamily')
     const defaultFont = "Menlo, Consolas, 'DejaVu Sans Mono', monospace"
     let overrideFont = config.style.fontFamily


### PR DESCRIPTION
This tried to address #59 

@UziTech So this doesnt work.... The only way to alter the cursor shape in a simple manner is to change the width/height in https://github.com/bus-stop/terminus/blob/d0028f0c42c97c4cc726fd5182213ec64c836577/styles/terminus.less#L106-L108

Doing it like this has no effect maybe I misunderstood something, but Yep Im a newb at this.

I tried other designs like injecting 

&.block {} class to terminal-cursor, but that also didnt work.

Maybe Im missing something obvious and didnt want to overcomplicate things for what should be changeable via css.

My design is based on.

>: block doesnt need any propeties really.

# I-Beam

```css
    .cursor-blink {
      .terminal-cursor {
        -webkit-animation: blink 1s step-start 0s infinite;
        -webkit-animation-delay: 1s;
        width: 2px;
        height: auto;
        @-webkit-keyframes blink {
          50%  { background: transparent; }
        }
      }
    }
``` 

# Underline
```css
    .cursor-blink {
      .terminal-cursor {
        -webkit-animation: blink 1s step-start 0s infinite;
        -webkit-animation-delay: 1s;
        width: auto;
        height: 2px;
        @-webkit-keyframes blink {
          50%  { background: transparent; }
        }
      }
    }
``` 

Help?

